### PR TITLE
[major] *Breaking* Bump react@16 and pull TestUtils from its new home…

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 /* eslint no-invalid-this: 0 */
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import React from 'react';
 
 export default function pluginAssumeReact(assume, util) {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "istanbul": "~0.4.0",
     "mocha": "~2.3.0",
     "pre-commit": "~1.1.0",
-    "react": "~0.14.2",
-    "react-addons-test-utils": "~0.14.2"
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0"
   }
 }


### PR DESCRIPTION
… in react-dom.

As part of an upgrading from `react@15` to `react@16`, I discovered that this component was still pulling TestUtils from it's old (pre `react@15.5`) location, which is now completely gone and doesn't work with `react@16` [See react@15.5 relnotes](https://reactjs.org/blog/2017/04/07/react-v15.5.0.html#react-test-utils).